### PR TITLE
Release keys for macOS users

### DIFF
--- a/keybd_darwin.go
+++ b/keybd_darwin.go
@@ -4,8 +4,12 @@ package keybd_event
  #cgo CFLAGS: -x objective-c
  #cgo LDFLAGS: -framework Cocoa
  #import <Foundation/Foundation.h>
- CGEventRef Create(int k){
+ CGEventRef CreateDown(int k){
 	CGEventRef event = CGEventCreateKeyboardEvent (NULL, (CGKeyCode)k, true);
+	return event;
+ }
+ CGEventRef CreateUp(int k){
+	CGEventRef event = CGEventCreateKeyboardEvent (NULL, (CGKeyCode)k, false);
 	return event;
  }
  void KeyTap(CGEventRef event){
@@ -62,27 +66,29 @@ func cmd(event C.CGEventRef) {
 	C.AddActionKey(_VK_CMD, event)
 }
 func (k KeyBonding) tapKey(key int) {
-	event := C.Create(C.int(key))
+	downEvent := C.CreateDown(C.int(key))
+	upEvent := C.CreateUp(C.int(key))
 	if k.hasALT {
-		alt(event)
+		alt(downEvent)
 	}
 	if k.hasCTRL {
-		ctrl(event)
+		ctrl(downEvent)
 	}
 	if k.hasSHIFT {
-		shift(event)
+		shift(downEvent)
 	}
 	if k.hasRCTRL { //not support on mac
-		ctrl(event)
+		ctrl(downEvent)
 	}
 	if k.hasRSHIFT { //not support on mac
-		shift(event)
+		shift(downEvent)
 	}
 	if k.hasALTGR {
-		altgr(event)
+		altgr(downEvent)
 	}
-	C.KeyTap(event)
+	C.KeyTap(downEvent)
 	time.Sleep(100 * time.Millisecond) //ignore if speed is most in my test system
+	C.KeyTap(upEvent)
 }
 
 const (


### PR DESCRIPTION
Hi @micmonay, very interesting project! :-)

I'm woking in a bot that plays Stardew Valley, and I've noticed an odd behaviour on macOS. When a key is pressed, it's not being released.

I've checked [this doc](https://developer.apple.com/documentation/coregraphics/1456564-cgeventcreatekeyboardevent?language=objc), and apparently this PR fixes the issue.

See my bot running before my changes:
![2019-05-19 16 48 22](https://user-images.githubusercontent.com/1079279/57987365-cefd6580-7a56-11e9-86bc-ded9f951cfa8.gif)

..and here's my bot running with the changes proposed by this PR:
![2019-05-19 16 47 07](https://user-images.githubusercontent.com/1079279/57987374-e2a8cc00-7a56-11e9-994e-0bab427c6b1b.gif)

Btw, here's the code that my bot performs:

```go

package main

import (
	"time"

	"github.com/micmonay/keybd_event"
)

func main() {

	time.Sleep(1 * time.Second)

	kb, err := keybd_event.NewKeyBonding()
	if err != nil {
		panic(err)
	}

	kb.SetKeys(keybd_event.VK_D)
	kb.Launching()
}

```