### PR TITLE
Added 'KeyBonding' methods for right control and shift.

### DIFF
--- a/keybd_event.go
+++ b/keybd_event.go
@@ -65,11 +65,15 @@ func (k *KeyBonding) HasALTGR(b bool) {
 }
 
 //HasCTRLR If key CTRLR pressed
+//
+//This is currently not supported on macOS
 func (k *KeyBonding) HasCTRLR(b bool) {
 	k.hasRCTRL = b
 }
 
 //HasSHIFTR If key SHIFTR pressed
+//
+//This is currently not supported on macOS
 func (k *KeyBonding) HasSHIFTR(b bool) {
 	k.hasRSHIFT = b
 }

--- a/keybd_event.go
+++ b/keybd_event.go
@@ -63,3 +63,13 @@ func (k *KeyBonding) HasSHIFT(b bool) {
 func (k *KeyBonding) HasALTGR(b bool) {
 	k.hasALTGR = b
 }
+
+//HasCTRLR If key CTRLR pressed
+func (k *KeyBonding) HasCTRLR(b bool) {
+	k.hasRCTRL = b
+}
+
+//HasSHIFTR If key SHIFTR pressed
+func (k *KeyBonding) HasSHIFTR(b bool) {
+	k.hasRSHIFT = b
+}


### PR DESCRIPTION
I noticed that the `KeyBonding.HAS*()` methods for right Control and right Shift were missing.

This pull request adds the missing methods.