### PR TITLE
Add go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # keybd_event
+
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/micmonay/keybd_event)
+
 This library simulates the key press on a keyboard. It runs on Linux, Windows and Mac.
 
 **Important :** 


### PR DESCRIPTION
There isn't a link to the generated godocs. It's faster to go to the docs with a link rather than having to search for them.

A link was added to the go.dev documentation