### PR TITLE
Export downKey(), upKey() and sync() for strict reproducing of user input.

### DIFF
--- a/keybd_linux_export.go
+++ b/keybd_linux_export.go
@@ -1,0 +1,15 @@
+package keybd_event
+
+// Export downKey(), upKey() and sync() for strict reproducing of user input.
+
+func (k *KeyBonding) Down(key uint16) error {
+	return downKey(int(key))
+}
+
+func (k *KeyBonding) Up(key uint16) error {
+	return upKey(int(key))
+}
+
+func (k *KeyBonding) Sync() error {
+	return sync()
+}


### PR DESCRIPTION
Hello,
Your virtual keyboard works excellent, but in [xswitcher](https://github.com/ds-voix/xswitcher) I have to reproduce keyboard events 1:1. (To retype the same in new layout).
I'd simply wrapped the downKey(), upKey() and sync() calls to make them public.

The virtual keyboard can now be implemented as:
```
// Scan-codes from "golang-evdev"
type t_key struct {
	code uint16;
	value int32; // 1=press 0=release; 2=repeat, but it must be trimmed
}

// Push or release the key on virtual keyboard
func sendKey(key t_key) {
	switch key.value {
	case 0:
		kb.Up(key.code)
		kb.Sync()
	default:
		kb.Down(key.code)
		kb.Sync()
	}
	time.Sleep(time.Duration(Keyboard.Delay) * time.Millisecond)
}
```
Regards!