### PR TITLE
Make it possible to target background applications in OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ Another subtlety on Linux: it is important after creating the `keybd_event` to *
 
 ## Darwin (MacOS)
 This library depends on Apple's frameworks, and I did not find a solution to cross-compile from another OS to MacOS.
+
+By default, the keypress will be sent to the active window only, but you can use the `NewKeyBondingWithPID` and provide an integer process id.

--- a/keybd_darwin.go
+++ b/keybd_darwin.go
@@ -16,6 +16,11 @@ package keybd_event
 	CGEventPost(kCGAnnotatedSessionEventTap, event);
 	CFRelease(event);
  }
+
+ void KeyTapPID(int pid, CGEventRef event){
+	CGEventPostToPid(pid, event);
+	CFRelease(event);
+ }
  void AddActionKey(CGEventFlags type,CGEventRef event){
  	CGEventSetFlags(event, type);
  }
@@ -104,7 +109,12 @@ func (k KeyBonding) keyPress(key int) {
 	if k.hasSuper {
 		cmd(downEvent)
 	}
-	C.KeyTap(downEvent)
+
+	if k.PID > 0 {
+		C.KeyTapPID(C.int(k.PID), downEvent)
+	} else {
+		C.KeyTap(downEvent)
+	}
 }
 func (k KeyBonding) keyRelease(key int) {
 	upEvent := C.CreateUp(C.int(key))
@@ -129,7 +139,12 @@ func (k KeyBonding) keyRelease(key int) {
 	if k.hasSuper {
 		cmd(upEvent)
 	}
-	C.KeyTap(upEvent)
+
+	if k.PID > 0 {
+		C.KeyTapPID(C.int(k.PID), upEvent)
+	} else {
+		C.KeyTap(upEvent)
+	}
 }
 func (k KeyBonding) tapKey(key int) {
 	k.keyPress(key)

--- a/keybd_event.go
+++ b/keybd_event.go
@@ -11,11 +11,25 @@ type KeyBonding struct {
 	hasALTGR  bool
 	hasSuper  bool
 	keys      []int
+
+	PID int
 }
 
 //NewKeyBonding Use for create struct KeyBounding
 func NewKeyBonding() (KeyBonding, error) {
 	keyBounding := KeyBonding{}
+	keyBounding.Clear()
+	err := initKeyBD()
+	if err != nil {
+		return keyBounding, err
+	}
+	return keyBounding, nil
+}
+
+//NewKeyBondingWithPID Use for create struct KeyBounding with target process ID
+//Note: Only implemented in Darwin (MacOS)
+func NewKeyBondingWithPID(pid int) (KeyBonding, error) {
+	keyBounding := KeyBonding{PID: pid}
 	keyBounding.Clear()
 	err := initKeyBD()
 	if err != nil {


### PR DESCRIPTION
Hi,

first of all, I know it's not a cross-platform solution, I'll try to make adjustments on other platforms (if they are possible, I'm open to any help/suggestion on this topic.).

My issue was that the keyboard events were sent only to the application/window in focus on OSX, but I wanted to control an OBS instance that was running in the background.
I cam across a possible solution via the [CGEventPostToPid](https://developer.apple.com/documentation/coregraphics/1454804-cgeventposttopid?language=objc) framework call.

For me this helped a lot, maybe could be useful for others too.
(I'm not that happy to introduce a new constructor, but that was the easiest a fastest for me.)