### PR TITLE
fix for new MacOS versions

### DIFF
--- a/keybd_darwin.go
+++ b/keybd_darwin.go
@@ -3,7 +3,7 @@ package keybd_event
 /*
  #cgo CFLAGS: -x objective-c
  #cgo LDFLAGS: -framework Cocoa
- #import <Foundation/Foundation.h>
+ #import <Cocoa/Cocoa.h>
  #import <ApplicationServices/ApplicationServices.h>
  CGEventRef CreateDown(int k){
 	CGEventRef event = CGEventCreateKeyboardEvent (NULL, (CGKeyCode)k, true);


### PR DESCRIPTION
Latest MacOS versions require other imports. Please, add a new version of your lib (for example v2) to support this.